### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ I use LLMs a lot so I've added a couple of scripts that make it easier to write 
     bin/code_for_prompt | bin/token_count
     ```
 
+## Contributing
+
+Pull Requests are welcome. If you find a bug or have a feature request I encourage you to follow the instructions above and then try out an LLM tool like GitHub Copilot, ChatGPT, or Claude to help you fix the bug or write the feature. Version 1 of this library was written entirely using LLMs, from feature ideas to bug fixes.
+
+Prompt driven development (aka [PBD](https://www.deeplearning.ai/the-batch/ai-at-the-speed-of-prompting/) or [PDP](https://www.ai4science.ai/post/prompt-driven-programming-a-new-software-development-paradigm)) is the future :rocket:
+
 ## Contributors
 
 - [@jonmagic](https://github.com/jonmagic)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ See [bin/demo](https://github.com/jonmagic/hawktui/blob/main/bin/demo) for an ex
 
 - Add functionality to StreamingTable for selecting and acting on rows.
 
+## Development
+
+Run the tests with:
+
+```bash
+rake
+```
+
+Run the standard linter and fix issues with:
+
+```bash
+rake standard:fix
+```
+
+I use LLMs a lot so I've added a couple of scripts that make it easier to write prompts.
+- [bin/code_for_prompt](https://github.com/jonmagic/hawktui/blob/main/bin/code_for_prompt) - This script will output everything in lib and test that you might need when providing a prompt with context. I usually pipe this to `pbcopy` and then paste it into the prompt.
+    ```bash
+    bin/code_for_prompt | pbcopy
+    ```
+- [bin/token_count](https://github.com/jonmagic/hawktui/blob/main/bin/token_count) - This script will output the number of tokens either piped to it or by running whatever is passed to it as a command. It defaults to counting for ChatGPT 4o but you can set the model to claude instead. Run the command without arguments to see the usage.
+    ```bash
+    bin/code_for_prompt | bin/token_count
+    ```
+
 ## Contributors
 
 - [@jonmagic](https://github.com/jonmagic)

--- a/bin/code_for_prompt
+++ b/bin/code_for_prompt
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+project_path=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+find $project_path/lib $project_path/test \
+  -name "*.rb" \
+  -type f \
+  -exec sh -c 'echo "### File: {}" && cat "{}" && echo' \;

--- a/bin/demo
+++ b/bin/demo
@@ -142,6 +142,10 @@ keybindings = {
       ui.navigate_up
     end
   },
+  # Clear all selections
+  "r" => ->(ui) {
+    ui.clear_selections
+  },
   # Pause/unpause
   "p" => ->(ui) { ui.toggle_pause },
   # Quit

--- a/bin/demo
+++ b/bin/demo
@@ -100,14 +100,16 @@ row_generator = Thread.new do
   loop do
     break if table.should_exit
 
-    # Generate a row of data
-    row_data = generate_row(id)
+    unless table.paused
+      # Generate a row of data
+      row_data = generate_row(id)
 
-    # Add row to the table
-    table.add_row(row_data)
+      # Add row to the table
+      table.add_row(row_data)
 
-    # Increment the ID
-    id += 1
+      # Increment the ID
+      id += 1
+    end
 
     # Respect the `paused` attribute
     sleep 0.1 while table.paused

--- a/bin/demo
+++ b/bin/demo
@@ -63,17 +63,93 @@ def generate_row(id)
   }
 end
 
+# Initial state
+initial_state = {
+  multi_select: false, # Whether multi-select mode is active
+  multi_select_direction: nil, # :up or :down (the most recent direction of multi-select scrolling)
+  multi_select_start_index: nil, # The row index where multi-select began
+}
+
 # Keybindings for the UI
 keybindings = {
-  " " => ->(ui) { ui.toggle_selection },
-  "KEY_DOWN" => ->(ui) { ui.toggle_pause unless ui.paused; ui.navigate_down },
-  Curses::KEY_UP => ->(ui) { ui.navigate_up },
+  # Toggle selection on the current row (single-row toggle)
+  " " => ->(ui) {
+    ui.toggle_selection
+  },
+  # Toggle multi-select mode
+  "m" => ->(ui) {
+    ui.state[:multi_select] = !ui.state[:multi_select]
+
+    if ui.state[:multi_select]
+      # We're enabling multi-select:
+      # 1) Mark the start index
+      ui.state[:multi_select_start_index] = ui.current_row_index
+      # 2) Reset the direction so next move sets it
+      ui.state[:multi_select_direction] = nil
+      # 3) Select the current row right away
+      ui.toggle_selection
+    else
+      # We're disabling multi-select:
+      # 1) Clear the start index
+      ui.state[:multi_select_start_index] = nil
+      # 2) Reset direction
+      ui.state[:multi_select_direction] = nil
+    end
+  },
+  # Move DOWN
+  "KEY_DOWN" => ->(ui) {
+    ui.toggle_pause unless ui.paused
+
+    if ui.state[:multi_select]
+      # If the last direction was 'up' but now we're going 'down', unselect current row (unless it's the start index)
+      if ui.state[:multi_select_direction] == :up && ui.current_row_index != ui.state[:multi_select_start_index]
+        ui.toggle_selection  # toggles OFF the current row
+      end
+
+      # Move down
+      ui.navigate_down
+
+      # Now toggle ON the new current row (unless it’s the start index you already have selected)
+      if ui.current_row_index != ui.state[:multi_select_start_index]
+        ui.toggle_selection
+      end
+
+      # Update direction
+      ui.state[:multi_select_direction] = :down
+    else
+      ui.navigate_down
+    end
+  },
+  # Move UP
+  Curses::KEY_UP => ->(ui) {
+    if ui.state[:multi_select]
+      # If the last direction was 'down' but now we're going 'up', unselect current row (unless it's the start index)
+      if ui.state[:multi_select_direction] == :down && ui.current_row_index != ui.state[:multi_select_start_index]
+        ui.toggle_selection  # toggles OFF the current row
+      end
+
+      # Move up
+      ui.navigate_up
+
+      # Now toggle ON the new current row (unless it’s the start index you already have selected)
+      if ui.current_row_index != ui.state[:multi_select_start_index]
+        ui.toggle_selection
+      end
+
+      # Update direction
+      ui.state[:multi_select_direction] = :up
+    else
+      ui.navigate_up
+    end
+  },
+  # Pause/unpause
   "p" => ->(ui) { ui.toggle_pause },
+  # Quit
   "q" => ->(ui) { ui.stop },
 }
 
 # Initialize the table
-table = Hawktui::StreamingTable.new(keybindings: keybindings)
+table = Hawktui::StreamingTable.new(keybindings: keybindings, state: initial_state)
 table.setup
 table.layout = Hawktui::StreamingTable::Layout.new(columns: [
   { name: "ID", width: 9 },

--- a/bin/demo
+++ b/bin/demo
@@ -142,6 +142,13 @@ keybindings = {
       ui.navigate_up
     end
   },
+  # Move down a page
+  Curses::KEY_NPAGE => ->(ui) {
+    ui.toggle_pause unless ui.paused
+    ui.navigate_page_down
+  },
+  # Move up a page
+  Curses::KEY_PPAGE => ->(ui) {ui.navigate_page_up },
   # Clear all selections
   "r" => ->(ui) {
     ui.clear_selections

--- a/bin/demo
+++ b/bin/demo
@@ -151,7 +151,11 @@ keybindings = {
   Curses::KEY_PPAGE => ->(ui) {ui.navigate_page_up },
   # Clear all selections
   "r" => ->(ui) {
+    ui.set_status_message("Cleared #{ui.selected_row_indices.size} selections", duration: 5)
     ui.clear_selections
+    ui.state[:multi_select] = false
+    ui.state[:multi_select_start_index] = nil
+    ui.state[:multi_select_direction] = nil
   },
   # Pause/unpause
   "p" => ->(ui) { ui.toggle_pause },
@@ -159,8 +163,15 @@ keybindings = {
   "q" => ->(ui) { ui.stop },
 }
 
+default_status = ->(ui) {
+  help_text = "Press 'p' to pause/unpause, space to select, 'q' to quit"
+  selection_info = "#{ui.selected_row_indices.size} rows selected"
+  status = ui.paused ? "PAUSED" : "RUNNING"
+  "DEMO | Status: #{status} | #{selection_info} | #{help_text}"
+}
+
 # Initialize the table
-table = Hawktui::StreamingTable.new(keybindings: keybindings, state: initial_state)
+table = Hawktui::StreamingTable.new(keybindings: keybindings, state: initial_state, status: default_status)
 table.setup
 table.layout = Hawktui::StreamingTable::Layout.new(columns: [
   { name: "ID", width: 9 },

--- a/bin/demo
+++ b/bin/demo
@@ -63,8 +63,17 @@ def generate_row(id)
   }
 end
 
+# Keybindings for the UI
+keybindings = {
+  " " => ->(ui) { ui.toggle_selection },
+  "KEY_DOWN" => ->(ui) { ui.toggle_pause unless ui.paused; ui.navigate_down },
+  Curses::KEY_UP => ->(ui) { ui.navigate_up },
+  "p" => ->(ui) { ui.toggle_pause },
+  "q" => ->(ui) { ui.stop },
+}
+
 # Initialize the table
-table = Hawktui::StreamingTable.new
+table = Hawktui::StreamingTable.new(keybindings: keybindings)
 table.setup
 table.layout = Hawktui::StreamingTable::Layout.new(columns: [
   { name: "ID", width: 9 },

--- a/bin/demo
+++ b/bin/demo
@@ -4,11 +4,13 @@ require "bundler/setup"
 require "faker"
 require "hawktui/streaming_table"
 
-# Function to pad the ID with a darker grey color for padding
-def padded_id(id)
-  id_str = id.to_s
-  padding_size = [9 - id_str.length, 0].max
-  ("0" * padding_size) + id_str
+def padded_string(str, len, padding: "0", string_color: 7, padding_color: 7)
+  str = str.to_s
+  padding_size = [len - str.length, 0].max
+  [
+    { value: (padding.to_s * padding_size), color: padding_color },
+    { value: str, color: string_color },
+  ]
 end
 
 # Function to generate a username and email address
@@ -37,7 +39,7 @@ def generate_row(id)
   username, email = username_and_email_generator(name)
 
   {
-    "ID" => padded_id(id),
+    "ID" => padded_string(id, 9, padding: "0", string_color: 244, padding_color: 239),
     "Username" => {
       value: username,
       color: 244,

--- a/bin/token_count
+++ b/bin/token_count
@@ -1,0 +1,94 @@
+#!/usr/bin/env ruby
+
+class TokenEstimator
+  DEFAULT_MODEL = "gpt-4o"
+
+  TOKEN_RATIOS = {
+    DEFAULT_MODEL => 4,
+    "claude" => 3.5
+  }.freeze
+
+  CODE_INDICATORS = [
+    "```", "def ", "class ", "function", "import ",
+    "{", "}", ";", "//", "/*", "*/", "#include"
+  ].freeze
+
+  def estimate_tokens(text, model: DEFAULT_MODEL)
+    normalized_text = text.strip.gsub(/\s+/, ' ')
+    char_count = normalized_text.length
+    word_count = normalized_text.split.length
+    ratio = TOKEN_RATIOS[model] || TOKEN_RATIOS[DEFAULT_MODEL]
+    estimated_tokens = (char_count / ratio).round
+    estimated_tokens = (estimated_tokens * 1.1).round if contains_code?(normalized_text)
+
+    {
+      estimated_tokens: estimated_tokens,
+      char_count: char_count,
+      word_count: word_count,
+      chars_per_token: (char_count.to_f / estimated_tokens).round(2),
+      model: model
+    }
+  end
+
+  private
+
+  def contains_code?(text)
+    CODE_INDICATORS.any? { |indicator| text.include?(indicator) }
+  end
+end
+
+def get_input_from_command(command)
+  `#{command}`.strip
+end
+
+def get_input_from_pipe
+  return nil unless STDIN.tty? == false
+  STDIN.read.strip
+end
+
+def print_usage
+  puts "Usage:"
+  puts "  1. Pipe input:    cat files/* | #{$PROGRAM_NAME} [--model=MODEL]"
+  puts "  2. Use command:   #{$PROGRAM_NAME} [--model=MODEL] 'command to run'"
+  puts "\nModels: gpt-4o (default), claude"
+  exit 1
+end
+
+def parse_args
+  model = TokenEstimator::DEFAULT_MODEL
+  command = nil
+
+  ARGV.each do |arg|
+    if arg.start_with?("--model=")
+      model = arg.split("=")[1]
+    elsif !arg.start_with?("--")
+      command = arg
+    end
+  end
+
+  [model, command]
+end
+
+def main
+  model, command = parse_args
+
+  # Get input either from pipe or command
+  input = get_input_from_pipe || (command && get_input_from_command(command))
+
+  if input.nil? || input.empty?
+    print_usage
+  end
+
+  result = TokenEstimator.new.estimate_tokens(input, model: model)
+
+  # Print results in a clean format
+  puts "\nToken Estimation Results:"
+  puts "------------------------"
+  puts "Model: #{result[:model]}"
+  puts "Estimated tokens: #{result[:estimated_tokens]}"
+  puts "Character count: #{result[:char_count]}"
+  puts "Word count: #{result[:word_count]}"
+  puts "Chars per token: #{result[:chars_per_token]}"
+end
+
+main if __FILE__ == $PROGRAM_NAME

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -193,7 +193,7 @@ module Hawktui
       formatted_header_cells = header_cells.zip(layout.columns).map do |cell, column|
         column.format_cell(cell)
       end
-      draw_row(0, formatted_header_cells)
+      win.attron(Curses::A_BOLD) { draw_row(0, formatted_header_cells) }
     end
 
     # Internal: Draw the body of the table (rows of data).

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -174,6 +174,14 @@ module Hawktui
       draw
     end
 
+    # Public: Clear all selected rows.
+    #
+    # Returns nothing.
+    def clear_selections
+      selected_row_indices.clear
+      draw
+    end
+
     # Public: Toggle whether the table is paused.
     # - When paused, the table stops updating and the current row is fixed.
     # - When unpaused, the table resumes updating and the current row and

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -162,6 +162,26 @@ module Hawktui
       draw
     end
 
+    # Public: Scroll down one page in the table.
+    #
+    # Returns nothing.
+    def navigate_page_down
+      max_display_rows = Curses.lines - 2
+      self.current_row_index = [current_row_index + max_display_rows, rows.size - 1].min
+      adjust_offset
+      draw
+    end
+
+    # Public: Scroll up one page in the table.
+    #
+    # Returns nothing.
+    def navigate_page_up
+      max_display_rows = Curses.lines - 2
+      self.current_row_index = [current_row_index - max_display_rows, 0].max
+      adjust_offset
+      draw
+    end
+
     # Public: Toggle whether the current row is selected.
     #
     # Returns nothing.

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -53,8 +53,8 @@ module Hawktui
     end
 
     # Public accessors
-    attr_reader :layout, :max_rows, :rows, :paused, :selected_row_indices, :should_exit
-    attr_accessor :current_row_index, :offset, :win
+    attr_reader :layout, :max_rows, :rows, :selected_row_indices, :should_exit
+    attr_accessor :current_row_index, :offset, :paused, :win
 
     # Public: Set the layout for the table. This will redraw the table with the new layout.
     #
@@ -169,6 +169,7 @@ module Hawktui
       when Curses::KEY_UP
         navigate_up
       when Curses::KEY_DOWN
+        toggle_pause unless paused
         navigate_down
       when " "  # Press space to toggle selection of the current row
         toggle_selection
@@ -220,13 +221,24 @@ module Hawktui
       draw
     end
 
-    # Internal: Toggle whether the table is paused. When paused, new rows
-    # are still collected but not rendered until unpaused.
+    # Internal: Toggle whether the table is paused.
+    # - When paused, the table stops updating and the current row is fixed.
+    # - When unpaused, the table resumes updating and the current row and
+    #   selections are reset.
     #
     # Returns nothing.
     def toggle_pause
-      @paused = !paused
+      self.paused = !paused
+
+      unless paused
+        # Reset selections and current row on resume
+        selected_row_indices.clear
+        self.current_row_index = 0
+        self.offset = 0
+      end
+
       draw_footer
+      draw unless paused
     end
 
     # Internal: Draw the entire table (header, rows, status line).

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -139,6 +139,60 @@ module Hawktui
       draw unless paused
     end
 
+    # Public: Navigate up one row in the table.
+    #
+    # Returns nothing.
+    def navigate_up
+      return if current_row_index <= 0
+
+      self.current_row_index -= 1
+      adjust_offset
+      draw
+    end
+
+    # Public: Navigate down one row in the table.
+    #
+    # Returns nothing.
+    def navigate_down
+      return if current_row_index >= rows.size - 1
+
+      self.current_row_index += 1
+      adjust_offset
+      draw
+    end
+
+    # Public: Toggle whether the current row is selected.
+    #
+    # Returns nothing.
+    def toggle_selection
+      if selected_row_indices.include?(current_row_index)
+        selected_row_indices.delete(current_row_index)
+      else
+        selected_row_indices.add(current_row_index)
+      end
+      draw
+    end
+
+    # Public: Toggle whether the table is paused.
+    # - When paused, the table stops updating and the current row is fixed.
+    # - When unpaused, the table resumes updating and the current row and
+    #   selections are reset.
+    #
+    # Returns nothing.
+    def toggle_pause
+      self.paused = !paused
+
+      unless paused
+        # Reset selections and current row on resume
+        selected_row_indices.clear
+        self.current_row_index = 0
+        self.offset = 0
+      end
+
+      draw_footer
+      draw unless paused
+    end
+
     # Internal: Set up curses, initialize colors, etc. Called by #start.
     #
     # Returns nothing.
@@ -178,28 +232,6 @@ module Hawktui
       end
     end
 
-    # Internal: Navigate up one row in the table.
-    #
-    # Returns nothing.
-    def navigate_up
-      return if current_row_index <= 0
-
-      self.current_row_index -= 1
-      adjust_offset
-      draw
-    end
-
-    # Internal: Navigate down one row in the table.
-    #
-    # Returns nothing.
-    def navigate_down
-      return if current_row_index >= rows.size - 1
-
-      self.current_row_index += 1
-      adjust_offset
-      draw
-    end
-
     # Internal: Adjust the offset to keep the current row in view.
     #
     # Returns nothing.
@@ -209,38 +241,6 @@ module Hawktui
       elsif current_row_index >= offset + Curses.lines
         self.offset = current_row_index - Curses.lines + 1
       end
-    end
-
-    # Internal: Toggle whether the current row is selected.
-    #
-    # Returns nothing.
-    def toggle_selection
-      if selected_row_indices.include?(current_row_index)
-        selected_row_indices.delete(current_row_index)
-      else
-        selected_row_indices.add(current_row_index)
-      end
-      draw
-    end
-
-    # Internal: Toggle whether the table is paused.
-    # - When paused, the table stops updating and the current row is fixed.
-    # - When unpaused, the table resumes updating and the current row and
-    #   selections are reset.
-    #
-    # Returns nothing.
-    def toggle_pause
-      self.paused = !paused
-
-      unless paused
-        # Reset selections and current row on resume
-        selected_row_indices.clear
-        self.current_row_index = 0
-        self.offset = 0
-      end
-
-      draw_footer
-      draw unless paused
     end
 
     # Internal: Draw the entire table (header, rows, status line).

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -236,10 +236,11 @@ module Hawktui
     #
     # Returns nothing.
     def adjust_offset
+      max_display_rows = Curses.lines - 2
       if current_row_index < offset
         self.offset = current_row_index
-      elsif current_row_index >= offset + Curses.lines
-        self.offset = current_row_index - Curses.lines + 1
+      elsif current_row_index >= offset + max_display_rows
+        self.offset = current_row_index - max_display_rows + 1
       end
     end
 

--- a/lib/hawktui/streaming_table.rb
+++ b/lib/hawktui/streaming_table.rb
@@ -52,7 +52,7 @@ module Hawktui
     #           )
     #
     # Returns a new StreamingTable instance.
-    def initialize(columns: {}, max_rows: 100_000, keybindings: {})
+    def initialize(columns: {}, max_rows: 100_000, keybindings: {}, state: {})
       @layout = Layout.new(columns: columns)
       @max_rows = max_rows
       @rows = [] # Store rows newest-first
@@ -62,6 +62,7 @@ module Hawktui
       @current_row_index = 0
       @offset = 0
       @selected_row_indices = Set.new
+      @state = state || {}
       @keybindings = keybindings.transform_keys { |key|
         begin
           Curses.const_get(key)
@@ -72,7 +73,7 @@ module Hawktui
     end
 
     # Public accessors
-    attr_reader :keybindings, :layout, :max_rows, :rows, :selected_row_indices, :should_exit
+    attr_reader :keybindings, :layout, :max_rows, :rows, :selected_row_indices, :should_exit, :state
     attr_accessor :current_row_index, :input_handler, :offset, :paused, :win
 
     # Public: Set the layout for the table. This will redraw the table with the new layout.

--- a/lib/hawktui/streaming_table/cell.rb
+++ b/lib/hawktui/streaming_table/cell.rb
@@ -2,40 +2,67 @@
 
 module Hawktui
   class StreamingTable
-    # Public: Represents a single cell in a table. Holds the cell’s value and
-    # optional color, and can return both in a consistent format.
+    # Public: Represents a single cell or group of cells in a table. Can hold either
+    # a single value with optional color, or an array of values/cells each with their
+    # own optional colors.
     #
     # Examples
     #
+    #   # Single value
     #   cell = Hawktui::StreamingTable::Cell.new("Hello")
     #   cell.value  # => "Hello"
     #   cell.color  # => nil
     #
-    #   colored_cell = Hawktui::StreamingTable::Cell.new(value: "Error", color: :red)
-    #   colored_cell.value  # => "Error"
-    #   colored_cell.color  # => :red
+    #   # Single cell with value and color set
+    #   cell = Hawktui::StreamingTable::Cell.new(value: "Error", color: :red)
+    #   cell.value  # => "Error"
+    #   cell.color  # => :red
+    #
+    #   # Array of values with different colors
+    #   multi_cell = Hawktui::StreamingTable::Cell.new([
+    #     { value: "00", color: :dark_grey },
+    #     { value: "42", color: :light_grey }
+    #   ])
+    #   multi_cell.components  # => [<Cell>, <Cell>]
     #
     class Cell
-      attr_reader :value, :color
+      attr_reader :value, :color, :components
 
-      # Public: Create a new Cell object from either a raw value or a Hash with
-      # `:value` and `:color` keys.
+      # Public: Create a new Cell object from either a raw value, a Hash with
+      # `:value` and `:color` keys, or an Array of such values/hashes.
       #
-      # value_or_hash - A raw value (e.g., String, Integer) or a Hash of the form:
-      #                 { value: <String/Integer>, color: <Symbol/Integer> }.
+      # value_or_hash_or_array - A raw value (e.g., String, Integer),
+      #                          a Hash of the form { value: <String/Integer>, color: <Symbol/Integer> },
+      #                          or an Array of such values/hashes.
       #
       # Examples
       #
       #   Cell.new("Hello")
       #   Cell.new(value: "Hello", color: :blue)
+      #   Cell.new([{ value: "00", color: :dark_grey }, { value: "42", color: :light_grey }])
       #
       # Returns a new Cell instance.
-      def initialize(value_or_hash)
-        @value, @color = extract_value_and_color(value_or_hash)
+      def initialize(value_or_hash_or_array)
+        if value_or_hash_or_array.is_a?(Array)
+          @components = value_or_hash_or_array.map { |v| Cell.new(v) }
+          @value = @components.map(&:value).join
+          @color = nil
+        else
+          @value, @color = extract_value_and_color(value_or_hash_or_array)
+          @components = nil
+        end
+      end
+
+      # Public: Check if this cell contains multiple components.
+      #
+      # Returns a Boolean.
+      def composite?
+        !components.nil?
       end
 
       # Internal: Extract the cell's value and color from the given parameter.
-      #           If value_or_hash is a Hash, expects :value and :color keys.
+      #
+      # If value_or_hash is a Hash, expects :value and :color keys.
       #
       # value_or_hash - A raw value or a Hash with :value and :color.
       #

--- a/lib/hawktui/streaming_table/column.rb
+++ b/lib/hawktui/streaming_table/column.rb
@@ -27,25 +27,45 @@ module Hawktui
         @width = width
       end
 
-      # Public: Format the cell’s textual value to fit within the column width.
-      # If the text is longer than `width`, it will be truncated with an ellipsis ("…").
-      # Otherwise, it’s left-padded with spaces to fill the width.
-      #
-      # cell - A Hawktui::StreamingTable::Cell containing the raw value and color.
+      # Public: Format a cell value to fit within the column's width.
       #
       # Examples
       #
-      #   cell = Hawktui::StreamingTable::Cell.new("Some message")
+      #   column = Hawktui::StreamingTable::Column.new(name: :message, width: 10)
+      #   cell = Hawktui::StreamingTable::Cell.new("A long message")
       #   column.format_cell(cell)
-      #   # => ["Some message        ", nil] # => example if width is bigger
+      #   # => ["A long me…", nil]
       #
-      # Returns an Array [formatted_string, color].
+      # cell - A Cell object containing the value and optional color to format.
+      #
+      # Returns an Array of [formatted_value, color] tuples:
+      #   - For simple cells: returns a single tuple [String, Symbol/Integer]
+      #   - For composite cells: returns an Array of such tuples
       def format_cell(cell)
-        str_value = cell.value.to_s
-        if str_value.size > width
-          [str_value[0...width - 1] + "…", cell.color]
+        if cell.composite?
+          # For composite cells, each component maintains its own color
+          cell.components.map do |component|
+            # Don't pad individual components of a composite cell
+            [component.value.to_s, component.color]
+          end
         else
-          [str_value.ljust(width), cell.color]
+          # For single cells, pad the entire value
+          formatted_value = format_value(cell.value)
+          [formatted_value, cell.color]
+        end
+      end
+
+      # Internal: Format a single value to fit within the column width.
+      #
+      # value - The value to format (converted to String).
+      #
+      # Returns a String padded or truncated to fit the column width.
+      def format_value(value)
+        str_value = value.to_s
+        if str_value.length >= width
+          str_value[0...width]
+        else
+          str_value.ljust(width)
         end
       end
     end

--- a/lib/hawktui/utils/input_handler.rb
+++ b/lib/hawktui/utils/input_handler.rb
@@ -1,0 +1,45 @@
+module Hawktui
+  module Utils
+    class InputHandler
+      # Public: Initialize a new InputHandler.
+      #
+      # keybindings - A Hash mapping keys to actions (Procs).
+      # ui          - The UI object that actions will interact with.
+      #
+      # Examples
+      #
+      #   keybindings = {
+      #     "p" => ->(ui) { ui.toggle_pause },
+      #     " " => ->(ui) { ui.toggle_selection },
+      #     Curses::KEY_DOWN => ->(ui) { ui.navigate_down }
+      #   }
+      #   ui = UI.new
+      #   input_handler = Hawktui::Utils::InputHandler.new(keybindings: keybindings, ui: ui)
+      #
+      def initialize(keybindings:, ui:)
+        @keybindings = keybindings
+        @ui = ui
+      end
+
+      attr_reader :keybindings, :ui
+
+      # Public: Handle input by executing the corresponding action.
+      #
+      # key - The key input as a String.
+      #
+      # Examples
+      #
+      #   input_handler.handle_input("a")
+      #   # Executes the action associated with "a"
+      #
+      #   input_handler.handle_input("b")
+      #   # Executes the action associated with "b"
+      #
+      def handle_input(key)
+        action = keybindings[key]
+
+        action&.call(ui)
+      end
+    end
+  end
+end

--- a/test/hawktui/streaming_table/test_cell.rb
+++ b/test/hawktui/streaming_table/test_cell.rb
@@ -9,18 +9,51 @@ describe Hawktui::StreamingTable::Cell do
       cell = Hawktui::StreamingTable::Cell.new("Hello")
       assert_equal "Hello", cell.value
       assert_nil cell.color
+      refute cell.composite?
     end
 
     it "initializes with a value and color from a hash" do
       cell = Hawktui::StreamingTable::Cell.new(value: "Error", color: :red)
       assert_equal "Error", cell.value
       assert_equal :red, cell.color
+      refute cell.composite?
     end
 
     it "handles a hash with only a value" do
       cell = Hawktui::StreamingTable::Cell.new(value: "Info")
       assert_equal "Info", cell.value
       assert_nil cell.color
+      refute cell.composite?
+    end
+
+    it "initializes with an array of values and colors" do
+      cell = Hawktui::StreamingTable::Cell.new([
+        {value: "00", color: :dark_grey},
+        {value: "42", color: :light_grey}
+      ])
+      assert_equal "0042", cell.value
+      assert_nil cell.color
+      assert cell.composite?
+      assert_equal 2, cell.components.size
+      assert_equal "00", cell.components[0].value
+      assert_equal :dark_grey, cell.components[0].color
+      assert_equal "42", cell.components[1].value
+      assert_equal :light_grey, cell.components[1].color
+    end
+
+    it "handles mixed array of raw values and hashes" do
+      cell = Hawktui::StreamingTable::Cell.new([
+        "Hello",
+        {value: "World", color: :blue}
+      ])
+      assert_equal "HelloWorld", cell.value
+      assert_nil cell.color
+      assert cell.composite?
+      assert_equal 2, cell.components.size
+      assert_equal "Hello", cell.components[0].value
+      assert_nil cell.components[0].color
+      assert_equal "World", cell.components[1].value
+      assert_equal :blue, cell.components[1].color
     end
   end
 

--- a/test/hawktui/streaming_table/test_column.rb
+++ b/test/hawktui/streaming_table/test_column.rb
@@ -16,38 +16,69 @@ describe Hawktui::StreamingTable::Column do
     let(:column) { Hawktui::StreamingTable::Column.new(name: :message, width: 10) }
 
     it "formats the cell value by truncating if it exceeds the column width" do
-      cell = Hawktui::StreamingTable::Cell.new("A long message")
+      cell = Hawktui::StreamingTable::Cell.new("Hello World!")
       formatted_value, color = column.format_cell(cell)
-      assert_equal "A long me…", formatted_value
+      assert_equal "Hello Worl", formatted_value
       assert_nil color
     end
 
     it "formats the cell value by padding with spaces if it is shorter than the column width" do
-      cell = Hawktui::StreamingTable::Cell.new("Short")
+      cell = Hawktui::StreamingTable::Cell.new("Hello")
       formatted_value, color = column.format_cell(cell)
-      assert_equal "Short     ", formatted_value
+      assert_equal "Hello     ", formatted_value
       assert_nil color
     end
 
     it "preserves the cell color when formatting" do
-      cell = Hawktui::StreamingTable::Cell.new(value: "Content", color: :green)
+      cell = Hawktui::StreamingTable::Cell.new(value: "Hello", color: :red)
       formatted_value, color = column.format_cell(cell)
-      assert_equal "Content   ", formatted_value
-      assert_equal :green, color
+      assert_equal "Hello     ", formatted_value
+      assert_equal :red, color
     end
 
     it "handles an empty string as the cell value" do
       cell = Hawktui::StreamingTable::Cell.new("")
       formatted_value, color = column.format_cell(cell)
-      assert_equal "          ", formatted_value
+      assert_equal " " * 10, formatted_value
       assert_nil color
     end
 
     it "handles non-string values in the cell" do
-      cell = Hawktui::StreamingTable::Cell.new(12345)
+      cell = Hawktui::StreamingTable::Cell.new(42)
       formatted_value, color = column.format_cell(cell)
-      assert_equal "12345     ", formatted_value
+      assert_equal "42        ", formatted_value
       assert_nil color
+    end
+
+    it "handles composite cells with multiple value/color tuples" do
+      cell = Hawktui::StreamingTable::Cell.new([
+        {value: "00", color: :dark_grey},
+        {value: "42", color: :light_grey}
+      ])
+      result = column.format_cell(cell)
+
+      assert_kind_of Array, result
+      assert_equal 2, result.size
+
+      value1, color1 = result[0]
+      value2, color2 = result[1]
+
+      assert_equal "00", value1
+      assert_equal :dark_grey, color1
+      assert_equal "42", value2
+      assert_equal :light_grey, color2
+    end
+
+    it "preserves colors in composite cells" do
+      cell = Hawktui::StreamingTable::Cell.new([
+        "plain",
+        {value: "fancy", color: :blue}
+      ])
+      result = column.format_cell(cell)
+
+      assert_equal 2, result.size
+      assert_equal ["plain", nil], result[0]
+      assert_equal ["fancy", :blue], result[1]
     end
   end
 end

--- a/test/hawktui/test_streaming_table.rb
+++ b/test/hawktui/test_streaming_table.rb
@@ -38,7 +38,7 @@ describe Hawktui::StreamingTable do
   end
 
   describe "#initialize" do
-    it "initializes with columns, max_rows, and actions" do
+    it "initializes with columns, max_rows, keybindings, and state" do
       assert_equal columns, table.layout.columns.map { |col| {name: col.name, width: col.width} }
       assert_equal max_rows, table.max_rows
       assert_equal [], table.rows
@@ -49,6 +49,7 @@ describe Hawktui::StreamingTable do
           key
         end
       }, table.keybindings
+      assert_equal({}, table.state)
       refute_nil table.win
       refute table.paused
       refute table.should_exit

--- a/test/hawktui/test_streaming_table.rb
+++ b/test/hawktui/test_streaming_table.rb
@@ -115,6 +115,19 @@ describe Hawktui::StreamingTable do
     end
   end
 
+  describe "#clear_selections" do
+    it "clears all selected rows" do
+      3.times { |i| table.add_row({timestamp: "2025-01-01 12:0#{i}", message: "Row #{i}"}) }
+      table.navigate_down
+      table.toggle_selection # Select row 1
+      table.navigate_down
+      table.toggle_selection # Select row 2
+      assert_equal 2, table.selected_row_indices.size
+      table.clear_selections
+      assert_equal 0, table.selected_row_indices.size
+    end
+  end
+
   describe "#draw_row" do
     it "draws composite cells with multiple colors" do
       sequence = sequence("drawing")

--- a/test/hawktui/test_streaming_table.rb
+++ b/test/hawktui/test_streaming_table.rb
@@ -214,6 +214,31 @@ describe Hawktui::StreamingTable do
     end
   end
 
+  describe "selected row functionality" do
+    it "toggles row selection with the spacebar" do
+      table.add_row({timestamp: "2025-01-01 12:00", message: "Row 1"})
+      table.add_row({timestamp: "2025-01-01 12:01", message: "Row 2"})
+
+      table.current_row_index = 0
+      table.toggle_selection
+      assert_includes table.selected_row_indices, 0
+
+      table.toggle_selection
+      refute_includes table.selected_row_indices, 0
+    end
+
+    it "highlights selected rows during rendering" do
+      table.add_row({timestamp: "2025-01-01 12:00", message: "Row 1"})
+      table.add_row({timestamp: "2025-01-01 12:01", message: "Row 2"})
+
+      table.current_row_index = 0
+      table.toggle_selection
+
+      @mock_window.expects(:attron).with(Curses::A_BOLD | Curses::A_REVERSE).yields
+      table.draw_body
+    end
+  end
+
   describe "#handle_input" do
     it 'toggles pause when "p" is pressed' do
       Curses.stubs(:getch).returns("p")

--- a/test/hawktui/test_streaming_table.rb
+++ b/test/hawktui/test_streaming_table.rb
@@ -230,7 +230,7 @@ describe Hawktui::StreamingTable do
       table.current_row_index = 12
       table.adjust_offset
 
-      assert_equal 3, table.offset
+      assert_equal 5, table.offset
     end
   end
 

--- a/test/hawktui/test_streaming_table.rb
+++ b/test/hawktui/test_streaming_table.rb
@@ -385,4 +385,46 @@ describe Hawktui::StreamingTable do
       table.input_handler.handle_input(Curses::KEY_DOWN)
     end
   end
+
+  describe "page navication" do
+    it "navigates down by a page" do
+      Curses.stubs(:lines).returns(10) # Mock 10 lines for terminal height
+      15.times { |i| table.add_row({timestamp: "2025-01-01 12:#{i.to_s.rjust(2, "0")}", message: "Row #{i}"}) }
+
+      table.current_row_index = 0
+      table.navigate_page_down
+
+      assert_equal 8, table.current_row_index
+    end
+
+    it "does not navigate past the last row" do
+      Curses.stubs(:lines).returns(10) # Mock 10 lines for terminal height
+      15.times { |i| table.add_row({timestamp: "2025-01-01 12:#{i.to_s.rjust(2, "0")}", message: "Row #{i}"}) }
+
+      table.current_row_index = 10
+      table.navigate_page_down
+
+      assert_equal 14, table.current_row_index
+    end
+
+    it "navigates up by a page" do
+      Curses.stubs(:lines).returns(10) # Mock 10 lines for terminal height
+      15.times { |i| table.add_row({timestamp: "2025-01-01 12:#{i.to_s.rjust(2, "0")}", message: "Row #{i}"}) }
+
+      table.current_row_index = 14
+      table.navigate_page_up
+
+      assert_equal 6, table.current_row_index
+    end
+
+    it "does not navigate past the first row" do
+      Curses.stubs(:lines).returns(10) # Mock 10 lines for terminal height
+      15.times { |i| table.add_row({timestamp: "2025-01-01 12:#{i.to_s.rjust(2, "0")}", message: "Row #{i}"}) }
+
+      table.current_row_index = 4
+      table.navigate_page_up
+
+      assert_equal 0, table.current_row_index
+    end
+  end
 end

--- a/test/hawktui/utils/test_input_handler.rb
+++ b/test/hawktui/utils/test_input_handler.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "hawktui/utils/input_handler"
+
+describe Hawktui::Utils::InputHandler do
+  describe "#initialize" do
+    it "sets up keybindings and UI" do
+      keybindings = {"q" => ->(ui) { ui.quit }}
+      ui = mock
+      input_handler = Hawktui::Utils::InputHandler.new(keybindings: keybindings, ui: ui)
+
+      assert_equal keybindings, input_handler.keybindings
+      assert_equal ui, input_handler.ui
+    end
+  end
+
+  describe "#handle_input" do
+    it "calls the action for the given key" do
+      keybindings = {"q" => ->(ui) { ui.quit }}
+      ui = mock
+      ui.expects(:quit).once
+      input_handler = Hawktui::Utils::InputHandler.new(keybindings: keybindings, ui: ui)
+
+      input_handler.handle_input("q")
+    end
+
+    it "does nothing for unknown keys" do
+      keybindings = {"q" => ->(ui) { ui.quit }}
+      ui = mock
+      ui.expects(:quit).never
+      input_handler = Hawktui::Utils::InputHandler.new(keybindings: keybindings, ui: ui)
+
+      input_handler.handle_input("a")
+    end
+  end
+end

--- a/test/support/mock_curses.rb
+++ b/test/support/mock_curses.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Mock implementation of Curses for testing
+module MockCurses
+  def self.init_screen
+  end
+
+  def self.start_color
+  end
+
+  def self.noecho
+  end
+
+  def self.curs_set(_)
+  end
+
+  def self.close_screen
+  end
+
+  def self.lines
+    24
+  end
+
+  def self.cols
+    80
+  end
+
+  def self.color_pair(_)
+    0
+  end
+
+  def self.timeout=(_)
+  end
+
+  def self.stdscr
+    @stdscr ||= MockWindow.new
+  end
+
+  class MockWindow
+    def keypad(_)
+    end
+
+    def clear
+    end
+
+    def refresh
+    end
+
+    def setpos(_, _)
+    end
+
+    def addstr(_)
+    end
+
+    def attron(_)
+      yield if block_given?
+    end
+  end
+
+  # Color Constants
+  COLOR_BLACK = 0
+  COLOR_RED = 1
+  COLOR_GREEN = 2
+  COLOR_YELLOW = 3
+  COLOR_BLUE = 4
+  COLOR_MAGENTA = 5
+  COLOR_CYAN = 6
+  COLOR_WHITE = 7
+
+  # Text Attributes
+  A_BOLD = 1
+  A_NORMAL = 0
+  A_REVERSE = 2
+end

--- a/test/support/mock_curses.rb
+++ b/test/support/mock_curses.rb
@@ -71,4 +71,8 @@ module MockCurses
   A_BOLD = 1
   A_NORMAL = 0
   A_REVERSE = 2
+
+  # Key Constants
+  KEY_UP = "KEY_UP"
+  KEY_DOWN = "KEY_DOWN"
 end


### PR DESCRIPTION
## Implementing Version 1.1.0 using LLMs

Here's the general process I follow for developing new features using LLMs.

> [!NOTE]
> I'm running these prompts against ChatGPT 4o and o1 pro mode and Claude 3.5 Sonnet, reviewing the results of each, and then choosing the one I think is best.

## Turn the idea into a plan

I start with a prompt like this:

> I want to update this library to support a current row, selecting rows, taking action on selected rows, automatically pausing when you start to navigate rows and select/deselect them, resetting current row to the first row when resuming, and more. For this request I just want you to think through how all of that might be implemented and give a recommended order of implementation if we do things iteratively in small chunks. I'll use the outline you give me in future prompts to implement each step.

Then I add all of the existing code to that prompt by running `bin/code_for_prompt | pbcopy` and pasting it into the prompt. The result from the LLM is something like this:

> Below is a high-level plan for adding the new features (current row, selecting rows, actions on selected rows, auto-pause on navigation, reset current row on resume, etc.) in small iterative steps. This roadmap focuses on incremental changes, so we add just enough in each step before moving on to the next. In future prompts, you can refer back to these steps and we’ll tackle each one in turn.
>
> 1. Track a “current row” and highlight it
>
> Goal: Introduce the concept of a “current row” in the table and visually highlight it.
> 	1.	Add a current_row_index attribute
> 	•	Initialize it to 0 (or nil if there are no rows yet).
> 	•	Update the draw_body method to check if idx (the loop index over rows) is the current row, and apply a different highlight (e.g., bold or inverse color).
> 	2.	Add basic keyboard navigation
> 	•	In handle_input, detect arrow-up (KEY_UP) and arrow-down (KEY_DOWN).
> 	•	Move current_row_index up or down, clamping to 0…(row_count - 1).
> 	•	Redraw the table so the newly current row is highlighted.
> 	3.	Scroll if the current row moves off-screen (optional at this stage)
> 	•	If you want, store an offset or start_display_row so when current_row_index is beyond the screen bottom, the table scrolls.
>
> This gets us minimal “current row” support and a sense of navigation.
>
> 2. Support selecting/deselecting rows
>
> Goal: Let the user “mark” or select multiple rows, each potentially with its own highlight.
> 	1.	Add a selected_row_indices data structure
> 	•	A simple Set that holds row indices (@selected_row_indices = Set.new), or an Array if you prefer.
> 	2.	Add a key to toggle selection
> 	•	In handle_input, if user presses (for example) the spacebar:
> 	•	If current_row_index is already in selected_row_indices, remove it.
> 	•	Otherwise, add it.
> 	•	This means pressing space while on a row toggles its selection.
> 	3.	Highlight selected rows
> 	•	In draw_body, if idx is in selected_row_indices, use a different color or style to indicate selection.
> 	•	If the row is both current and selected, decide on a priority or a combined highlight style.
>
> At this point, we can visually move a cursor around the table, press space to select or deselect, and see which rows are selected.
>
> 3. Automatically pause when navigation starts
>
> Goal: If the user presses an arrow key to navigate, the table should pause so new rows aren’t immediately redrawn out from under the user.
> 	1.	Update navigation input
> 	•	When KEY_UP or KEY_DOWN is detected:
> 	•	If the table is not already paused, call toggle_pause to pause immediately.
> 	•	Then handle the usual navigation logic.
> 	2.	Keep existing pause/unpause key
> 	•	The user can still press p to manually pause/unpause.
>
> With this, the moment a user tries to move the current row, the stream is paused automatically.
>
> 4. Reset current row to the first row when resuming
>
> Goal: Once unpaused (manually or otherwise), jump the current row back to the top.
> 	1.	Modify toggle_pause or introduce a separate method
> 	•	When transitioning from paused → unpaused, set @current_row_index = 0.
> 	•	Clear any scroll offset if implemented.
> 	2.	Visually confirm
> 	•	Ensure the next draw after unpausing shows the highlight on the top row again.
>
> Now the user’s navigation state is “reset” each time they resume.
>
> 5. Take an action on selected rows
>
> Goal: Provide a way to perform an operation (e.g., “delete rows,” “show details,” “export,” etc.) on all selected rows.
> 	1.	Add a new key binding
> 	•	For example, if the user presses a, call an apply_action_to_selected_rows method.
> 	2.	Implement apply_action_to_selected_rows
> 	•	Iterate through @selected_row_indices.
> 	•	For each selected row, do something (logging, removing from the table, opening a detail view, etc.).
> 	•	Clear @selected_row_indices if you want to reset selection afterward (depends on your use case).
> 	3.	Update UI
> 	•	Possibly show a message in the footer, e.g., “Action applied to N selected rows.”
>
> This is the core of “taking action on selected rows.”
>
> 6. Further enhancements & refinements
>
> Once you have the basics working, you can consider:
> 	•	Scrolling Behavior:
> Fine-tune how you handle large numbers of rows and how to ensure the current row is always visible.
> 	•	Selection & Shift+Select:
> Let the user hold Shift to select a range of rows at once if desired.
> 	•	Page Up / Page Down:
> Jump multiple rows at a time.
> 	•	Alternative “current row” resets:
> Instead of always resetting to the top row, you might reset to the last row or keep it at the same index if that’s more intuitive.
> 	•	Actions in a separate thread:
> If the “action” is time-consuming, you may want to queue it in a separate thread or job so the UI remains responsive.
> 	•	Transient messages or status bar:
> Provide feedback to the user when they do certain actions (e.g., “3 rows selected”).
>
> Summary
>
> This plan walks you through adding each feature in small steps, focusing on one piece at a time:
> 	1.	Current row & highlight
> 	2.	Selecting/deselecting
> 	3.	Auto-pause on navigation
> 	4.	Reset current row when resuming
> 	5.	Action on selected rows
> 	6.	Refinements & advanced features
>
> With this outline, you can tackle each step in a dedicated prompt or pull request, ensuring the code remains testable and stable as it evolves.

**Winner:** ChatGPT o1 pro mode.

## Implement `Track a “current row” and highlight it`

```
> 1. Track a “current row” and highlight it
>
> Goal: Introduce the concept of a “current row” in the table and visually highlight it.
> 	1.	Add a current_row_index attribute
> 	•	Initialize it to 0 (or nil if there are no rows yet).
> 	•	Update the draw_body method to check if idx (the loop index over rows) is the current row, and apply a different highlight (e.g., bold or inverse color).
> 	2.	Add basic keyboard navigation
> 	•	In handle_input, detect arrow-up (KEY_UP) and arrow-down (KEY_DOWN).
> 	•	Move current_row_index up or down, clamping to 0…(row_count - 1).
> 	•	Redraw the table so the newly current row is highlighted.
> 	3.	Scroll if the current row moves off-screen (optional at this stage)
> 	•	If you want, store an offset or start_display_row so when current_row_index is beyond the screen bottom, the table scrolls.
>
> This gets us minimal “current row” support and a sense of navigation.
```

Then I add all of the existing code to that prompt by running `bin/code_for_prompt | pbcopy` and pasting it into the prompt. You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/acadca750faddabb898355392cf1a97c728e81a7).

**Winner:** ChatGPT 4o but Claude was a close second.

https://github.com/user-attachments/assets/f9679348-e80c-462f-9fed-8fd8b5c5727e

## Implement `Support selecting/deselecting rows`

```
> 2. Support selecting/deselecting rows
>
> Goal: Let the user “mark” or select multiple rows, each potentially with its own highlight.
> 	1.	Add a selected_row_indices data structure
> 	•	A simple Set that holds row indices (@selected_row_indices = Set.new), or an Array if you prefer.
> 	2.	Add a key to toggle selection
> 	•	In handle_input, if user presses (for example) the spacebar:
> 	•	If current_row_index is already in selected_row_indices, remove it.
> 	•	Otherwise, add it.
> 	•	This means pressing space while on a row toggles its selection.
> 	3.	Highlight selected rows
> 	•	In draw_body, if idx is in selected_row_indices, use a different color or style to indicate selection.
> 	•	If the row is both current and selected, decide on a priority or a combined highlight style.
>
> At this point, we can visually move a cursor around the table, press space to select or deselect, and see which rows are selected.
```

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/a5b5d9d90422999b521034e9f77c9f441a57bb42).

**Winner:** ChatGPT o1 pro mode plus a little Claude for the footer. Also had to use some of my own brain to figure out a test bug that was related to the cell string being padded due to column width.

https://github.com/user-attachments/assets/2e3e482c-ba31-48fc-910b-1db48bebc8ab

## Implement `Automatically pause when navigation starts`

```
> 3. Automatically pause when navigation starts
>
> Goal: If the user presses an arrow key to navigate, the table should pause so new rows aren’t immediately redrawn out from under the user.
> 	1.	Update navigation input
> 	•	When KEY_UP or KEY_DOWN is detected:
> 	•	If the table is not already paused, call toggle_pause to pause immediately.
> 	•	Then handle the usual navigation logic.
> 	2.	Keep existing pause/unpause key
> 	•	The user can still press p to manually pause/unpause.
>
> With this, the moment a user tries to move the current row, the stream is paused automatically.
```

I also added something I forgot in the original prompt and then the code of course:

```
When resuming reset the selected rows to none and the current row to the first row.
```

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/630ec222073d4d9f721945f7ba4ccc63acb45b8e).

**Winner:** Claude 3.5 Sonnet. I also had to contribute a bit to work through bugs and I realized that you only need to pause on KEY_DOWN since the unpaused state always has current_row_index at 0.

https://github.com/user-attachments/assets/006e4962-34df-49a0-b152-5ae8e5b3617c

I also realized this completed step `Reset current row to the first row when resuming` as well :smile:

## Implement `Take an action on selected rows`

```
> 5. Take an action on selected rows
>
> Goal: Provide a way to perform an operation (e.g., “delete rows,” “show details,” “export,” etc.) on all selected rows.
> 	1.	Add a new key binding
> 	•	For example, if the user presses a, call an apply_action_to_selected_rows method.
> 	2.	Implement apply_action_to_selected_rows
> 	•	Iterate through @selected_row_indices.
> 	•	For each selected row, do something (logging, removing from the table, opening a detail view, etc.).
> 	•	Clear @selected_row_indices if you want to reset selection afterward (depends on your use case).
> 	3.	Update UI
> 	•	Possibly show a message in the footer, e.g., “Action applied to N selected rows.”
>
> This is the core of “taking action on selected rows.”
```

That starting prompt wasn't nearly enought to get the job done. I ended up breaking it down into many small prompts and half a dozen spikes and restarts before I got it working the way I want. **In the end I replaced all existing keybound functionality with the new configurable keybindings ability.**

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/860adb23e6a9aca58f5928fbe1a7ffd5d5334cc9).

**Winner:** All of them? None of them? I used every LLM as inspiration and wrote the code myself.

## Fix `row added after pressing p or navigating down`

```
I'm seeing issues where I start to navigate, the demo pauses as intended when arrow down is pressed, but then it renders one more row change when I press another key. Am I missing a draw somewhere or do I have an extra one somewhere? Is there a way to ensure a key press is handled immediately?

Below is the current implementation and demo.
```

**Winner:** Me :smile: I figured this one out before using the LLMs. I started looking at the demo code and saw that I might call `table.add_row(row_data)` after it had been paused so moving that inside an `unless table.paused` block fixed the issue.

## Fix `Scrolling Behavior`

```
When I scroll down the table and scroll to rows past the bottom I lose track of current_row because it's below the footer. I want the current row to always be visible even when I scroll down to rows that had previously been off-screen.

Below is the current implementation and demo.
```

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/826e717be86b4d6630892830c8b38352f11b47e1).

**Winner:** ChatGPT 4o.

https://github.com/user-attachments/assets/503e65bf-6a9a-46d3-8351-7bad3fa89950

## Implement `Range Selection`

I had to work on this prompt quite a bit.

```
I want to implement a new feature. Right now when you press space it selects the current row. If you continue holding space down and press arrow keys it will select multiple rows until you release the space key.

Reminder that all keybindings are defined in the keybindings hash in the StreamingTable class so we can't add key specific state to the StreamingTable class. We can add a state hash to the StreamingTable class that is accessible from the InputHandler class so that it can be used inside of the keybindings config.

Below is the current implementation and demo.
```

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/7588ff7eafff9ec74ace45ebb5cc571f360c1531).

**Winner:** ChatGPT 4o for initial version but then o1 pro mode to get the state and logic exactly right.

https://github.com/user-attachments/assets/fc514814-bc9f-4b6f-8c1b-77d2ddb30094

## Implement `Page Up / Page Down`

```
I want to implement a new feature. When the user presses the page up key the table should scroll up a page and when the user presses the page down key the table should scroll down a page.

Below is the current implementation and demo.
```

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/19bf6df2bf105fcfe01c1660ead54c4ffe5f7416).

**Winner:** ChatGPT 4o.

## Implement status bar API

```
I want to implement a new feature. I want to be able to customize the content of the status bar at the bottom of the table that can be updated with messages. The status bar should be able to display a message for a certain amount of time and then clear itself.

Below is the current implementation and demo.
```

You can see the result in [this commit](https://github.com/jonmagic/hawktui/commit/7de10b0397405261aaf901c6060160041f5bcde1).

**Winner:** ChatGPT 4o with a bit of back and forth iteration to meet my requirements.

https://github.com/user-attachments/assets/be075d8b-a215-4e27-b70c-495fd60d298d
